### PR TITLE
Added tablet selector

### DIFF
--- a/Area_Calculator.py
+++ b/Area_Calculator.py
@@ -5,6 +5,9 @@ from pynput.mouse import Listener
 import typer
 from rich.progress import track
 from rich import print as rprint
+import pick
+
+from tablets import tablets
 
 SAMPLE_RATE = 0.01
 GRACE_PERIOD = 5
@@ -70,8 +73,8 @@ def find_peak_near_extremes(
 def analyze_data(
     x_input: np.ndarray[np.uint16],
     y_input: np.ndarray[np.uint16],
-    tablet_width_mm: int,
-    tablet_height_mm: int,
+    tablet_width_mm: float,
+    tablet_height_mm: float,
     innergameplay_width_px: int,
     innergameplay_height_px: int,
 ):
@@ -117,6 +120,40 @@ def analyze_data(
     rprint("===================")
 
 
+def prompt_tablet_picker() -> tuple[float, float] | None:
+    brand, _ = pick.pick(
+        sorted(tablets.keys()),
+        title="Select your tablet brand (press Q if your tablet is not listed)",
+        indicator="→",
+        clear_screen=False,
+        quit_keys=[ord("q"), ord("Q")],
+    )
+    if not brand:
+        return
+    model, _ = pick.pick(
+        sorted(tablets[brand].keys()),
+        title="Select your tablet model (press Q if your tablet is not listed)",
+        indicator="→",
+        clear_screen=False,
+        quit_keys=[ord("q"), ord("Q")],
+    )
+    if not model:
+        return
+    width = tablets[brand][model]["width"]
+    height = tablets[brand][model]["height"]
+    return width, height
+
+
+def prompt_manual_tablet_info() -> tuple[float, float]:
+    tablet_width_mm = typer.prompt(
+        "Enter your full active tablet area width in mm", type=float
+    )
+    tablet_height_mm = typer.prompt(
+        "Enter your full active tablet area height in mm", type=float
+    )
+    return tablet_width_mm, tablet_height_mm
+
+
 def main(
     screen_width_px: Annotated[
         int, typer.Option(prompt="Enter your screen width in pixels", min=800)
@@ -124,18 +161,17 @@ def main(
     screen_height_px: Annotated[
         int, typer.Option(prompt="Enter your screen height in pixels", min=600)
     ],
-    tablet_width_mm: Annotated[
-        float,
-        typer.Option(prompt="Enter your full active tablet area width in mm", min=1),
-    ],
-    tablet_height_mm: Annotated[
-        float,
-        typer.Option(prompt="Enter your full active tablet area height in mm", min=1),
-    ],
     duration: Annotated[
         int, typer.Option(prompt="Enter map duration in seconds", min=10)
     ],
 ):
+    tablet = prompt_tablet_picker()
+
+    if tablet is None:
+        tablet_width_mm, tablet_height_mm = prompt_manual_tablet_info()
+    else:
+        tablet_width_mm, tablet_height_mm = tablet
+
     innergameplay_height_px = int((864 / 1080) * screen_height_px)
     innergameplay_width_px = int((1152 / 1920) * screen_width_px)
     typer.confirm(
@@ -162,7 +198,7 @@ def main(
             screen_height_px,
             tablet_width_mm,
             tablet_height_mm,
-            duration,
+            typer.prompt("Enter map duration in seconds", default=duration, type=int),
         )
     rprint("===================")
     rprint("Thank you for using the Area Calculator!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,17 @@
 [project]
 name = "area-calculator-osu"
-version = "0.2.1"
+version = "0.4.0"
 description = "TODO"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "numpy>=2.2.4",
+    "pick>=2.4.0",
     "pynput>=1.8.1",
     "typer>=0.15.2",
+]
+
+[dependency-groups]
+dev = [
+    "pyinstaller>=6.12.0",
 ]

--- a/tablets.py
+++ b/tablets.py
@@ -1,0 +1,1193 @@
+# This is just an extract from OpenTabletDriver
+# https://github.com/OpenTabletDriver/OpenTabletDriver/tree/master/OpenTabletDriver.Configurations/Configurations
+
+tablets: dict[str, dict[str, dict[str, float]]] = {
+    "Artisul": {
+        "D16 Pro": {
+            "width": 344.17,
+            "height": 193.57
+        },
+        "A1201": {
+            "width": 258.45,
+            "height": 171.55
+        },
+        "AP604": {
+            "width": 159,
+            "height": 99.3
+        },
+        "M0610 Pro": {
+            "width": 257.375,
+            "height": 161.49
+        }
+    },
+    "Veikk": {
+        "S640": {
+            "width": 152.4,
+            "height": 101.6
+        },
+        "VK1060": {
+            "width": 254,
+            "height": 158.75
+        },
+        "VK430": {
+            "width": 101.6,
+            "height": 76.2
+        },
+        "A50": {
+            "width": 254,
+            "height": 152.4
+        },
+        "A50 (Variant 2)": {
+            "width": 254,
+            "height": 152.4
+        },
+        "VK640": {
+            "width": 152.4,
+            "height": 101.6
+        },
+        "VK1060PRO": {
+            "width": 254,
+            "height": 158.75
+        },
+        "A30 V2": {
+            "width": 254,
+            "height": 158.75
+        },
+        "A15 Pro": {
+            "width": 254,
+            "height": 152.4
+        },
+        "S640 V2": {
+            "width": 152.4,
+            "height": 101.6
+        },
+        "VO1060": {
+            "width": 254,
+            "height": 158.75
+        },
+        "VK430 V2": {
+            "width": 101.6,
+            "height": 76.2
+        },
+        "A30": {
+            "width": 254,
+            "height": 152.4
+        },
+        "A15 V2": {
+            "width": 254,
+            "height": 152.4
+        },
+        "A15": {
+            "width": 254,
+            "height": 152.4
+        }
+    },
+    "Parblo": {
+        "Ninos N7": {
+            "width": 177.8,
+            "height": 111.09
+        },
+        "Intangbo S": {
+            "width": 177.5,
+            "height": 103.5
+        },
+        "A610 Pro": {
+            "width": 255.5,
+            "height": 160
+        },
+        "Ninos M": {
+            "width": 217.1954,
+            "height": 125.22
+        },
+        "Intangbo M": {
+            "width": 260.5,
+            "height": 160
+        },
+        "A610": {
+            "width": 254,
+            "height": 152.4
+        },
+        "A640": {
+            "width": 155,
+            "height": 93
+        },
+        "Ninos S": {
+            "width": 152,
+            "height": 95
+        },
+        "A640 V2": {
+            "width": 150,
+            "height": 90
+        },
+        "A609": {
+            "width": 223.52,
+            "height": 139.7
+        },
+        "Ninos N4": {
+            "width": 108,
+            "height": 81
+        },
+        "Ninos N7B": {
+            "width": 177.8,
+            "height": 114
+        }
+    },
+    "Adesso": {
+        "Cybertablet K8": {
+            "width": 203.2,
+            "height": 114.3
+        }
+    },
+    "Xencelabs": {
+        "Pen Tablet Small": {
+            "width": 178,
+            "height": 101
+        },
+        "Pen Tablet Medium": {
+            "width": 261.62,
+            "height": 148
+        }
+    },
+    "Kenting": {
+        "K5540": {
+            "width": 139.6873,
+            "height": 101.5873
+        }
+    },
+    "Viewsonic": {
+        "Woodpad PF1030": {
+            "width": 224,
+            "height": 140
+        },
+        "Woodpad PF0730": {
+            "width": 168,
+            "height": 106.4
+        }
+    },
+    "Xenx": {
+        "X1-640": {
+            "width": 152,
+            "height": 95
+        },
+        "P1-640": {
+            "width": 168,
+            "height": 105
+        },
+        "P3-1060": {
+            "width": 254,
+            "height": 158.75
+        }
+    },
+    "Genius": {
+        "G-Pen 560": {
+            "width": 152.3873,
+            "height": 114.2873
+        },
+        "i405x": {
+            "width": 140.5,
+            "height": 102.4
+        },
+        "i608x": {
+            "width": 203.2,
+            "height": 152.4
+        }
+    },
+    "Lifetec": {
+        "LT9570": {
+            "width": 300,
+            "height": 225
+        }
+    },
+    "Trust": {
+        "Flex Design Tablet": {
+            "width": 153.6,
+            "height": 115.2
+        }
+    },
+    "Wacom": {
+        "GD-1212-U": {
+            "width": 304.8,
+            "height": 316.8
+        },
+        "XD-0405-U": {
+            "width": 127,
+            "height": 106
+        },
+        "PTK-640": {
+            "width": 223.52,
+            "height": 139.7
+        },
+        "CTL-671": {
+            "width": 216,
+            "height": 135
+        },
+        "DTH-135": {
+            "width": 297.76,
+            "height": 169.24
+        },
+        "CTL-6100": {
+            "width": 216,
+            "height": 135
+        },
+        "CTL-4100WL": {
+            "width": 152,
+            "height": 95
+        },
+        "CTL-480": {
+            "width": 152,
+            "height": 95
+        },
+        "ET-0405A-U": {
+            "width": 127.6,
+            "height": 92.8
+        },
+        "PTZ-431W": {
+            "width": 157.48,
+            "height": 98.425
+        },
+        "DTK-1300": {
+            "width": 299,
+            "height": 171
+        },
+        "CTE-630": {
+            "width": 208.8,
+            "height": 150.8
+        },
+        "CTE-640": {
+            "width": 208.8,
+            "height": 150.8
+        },
+        "CTL-6100WL": {
+            "width": 216,
+            "height": 135
+        },
+        "CTH-460": {
+            "width": 147.2,
+            "height": 92
+        },
+        "PTK-1240": {
+            "width": 487.68,
+            "height": 304.8
+        },
+        "CTL-4100": {
+            "width": 152,
+            "height": 95
+        },
+        "XD-1218-U": {
+            "width": 457.2,
+            "height": 316.8
+        },
+        "PTH-660": {
+            "width": 224,
+            "height": 148
+        },
+        "PTH-451": {
+            "width": 157.48,
+            "height": 98.425
+        },
+        "XD-0608-U": {
+            "width": 203.2,
+            "height": 162.4
+        },
+        "XD-0912-U": {
+            "width": 304.8,
+            "height": 240.6
+        },
+        "CTH-490": {
+            "width": 152,
+            "height": 95
+        },
+        "PTU-600U": {
+            "width": 204.8,
+            "height": 153.6
+        },
+        "PTZ-930": {
+            "width": 304.8,
+            "height": 228.6
+        },
+        "CTE-450": {
+            "width": 147.6,
+            "height": 92.25
+        },
+        "PTK-840": {
+            "width": 325.12,
+            "height": 203.2
+        },
+        "CTE-430": {
+            "width": 127.6,
+            "height": 92.8
+        },
+        "DTH-1320": {
+            "width": 297.76,
+            "height": 169.24
+        },
+        "CTH-680": {
+            "width": 216,
+            "height": 135
+        },
+        "GD-1218-U": {
+            "width": 457.2,
+            "height": 316.8
+        },
+        "CTE-460": {
+            "width": 152,
+            "height": 95
+        },
+        "CTC-6110WL": {
+            "width": 216,
+            "height": 135
+        },
+        "GD-0405-U": {
+            "width": 127,
+            "height": 106
+        },
+        "CTH-670": {
+            "width": 216.48,
+            "height": 137
+        },
+        "CTL-690": {
+            "width": 216,
+            "height": 135
+        },
+        "DTH-271": {
+            "width": 600.16,
+            "height": 339.34
+        },
+        "CTL-471": {
+            "width": 152,
+            "height": 95
+        },
+        "PTH-651": {
+            "width": 223.52,
+            "height": 139.7
+        },
+        "FT-0405-U": {
+            "width": 127.6,
+            "height": 92.8
+        },
+        "DTC-133": {
+            "width": 294.34,
+            "height": 165.56
+        },
+        "PTZ-430": {
+            "width": 127,
+            "height": 101.6
+        },
+        "PTK-450": {
+            "width": 157.48,
+            "height": 98.425
+        },
+        "CTF-430": {
+            "width": 127.6,
+            "height": 92.8
+        },
+        "PTH-851": {
+            "width": 325.12,
+            "height": 203.2
+        },
+        "CTL-680": {
+            "width": 216,
+            "height": 135
+        },
+        "PTH-460": {
+            "width": 159.6,
+            "height": 99.75
+        },
+        "DTK-2200": {
+            "width": 479,
+            "height": 271
+        },
+        "PTK-440": {
+            "width": 157.48,
+            "height": 98.425
+        },
+        "PTZ-1231W": {
+            "width": 487.68,
+            "height": 304.8
+        },
+        "PTH-450": {
+            "width": 157.48,
+            "height": 98.425
+        },
+        "PTZ-1230": {
+            "width": 304.8,
+            "height": 304.8
+        },
+        "CTL-472": {
+            "width": 152,
+            "height": 95
+        },
+        "CTE-650": {
+            "width": 216.48,
+            "height": 135.3
+        },
+        "XD-1212-U": {
+            "width": 304.8,
+            "height": 316.8
+        },
+        "DTK-1660": {
+            "width": 348.16,
+            "height": 197.59
+        },
+        "CTH-690": {
+            "width": 216,
+            "height": 135
+        },
+        "CTH-300": {
+            "width": 107,
+            "height": 67
+        },
+        "GD-0912-U": {
+            "width": 304.8,
+            "height": 240.6
+        },
+        "CTC-4110WL": {
+            "width": 152,
+            "height": 95
+        },
+        "PTH-650": {
+            "width": 223.52,
+            "height": 139.7
+        },
+        "PTK-540WL": {
+            "width": 203.2,
+            "height": 127
+        },
+        "CTH-301": {
+            "width": 107,
+            "height": 67
+        },
+        "DTZ-1200W": {
+            "width": 261.1,
+            "height": 163.2
+        },
+        "PTH-850": {
+            "width": 325.12,
+            "height": 203.2
+        },
+        "CTH-461": {
+            "width": 147.2,
+            "height": 92
+        },
+        "CTH-480": {
+            "width": 152,
+            "height": 95
+        },
+        "MTE-450": {
+            "width": 147.6,
+            "height": 92.25
+        },
+        "PTZ-630": {
+            "width": 203.2,
+            "height": 152.4
+        },
+        "PTK-650": {
+            "width": 223.52,
+            "height": 139.7
+        },
+        "CTL-672": {
+            "width": 216,
+            "height": 135
+        },
+        "CTL-460": {
+            "width": 147.2,
+            "height": 92
+        },
+        "CTE-440": {
+            "width": 127.6,
+            "height": 92.8
+        },
+        "PTZ-631W": {
+            "width": 271.02,
+            "height": 158.75
+        },
+        "CTL-470": {
+            "width": 147.2,
+            "height": 92
+        },
+        "CTH-470": {
+            "width": 147.2,
+            "height": 92
+        },
+        "ET-0405-U": {
+            "width": 127.6,
+            "height": 92.8
+        },
+        "CTL-490": {
+            "width": 152,
+            "height": 95
+        },
+        "CTE-660": {
+            "width": 216.48,
+            "height": 135
+        },
+        "PTH-860": {
+            "width": 311,
+            "height": 216
+        },
+        "GD-0608-U": {
+            "width": 203.2,
+            "height": 162.4
+        },
+        "CTH-661": {
+            "width": 216.48,
+            "height": 137
+        }
+    },
+    "Floogoo": {
+        "FMA100": {
+            "width": 262.128,
+            "height": 196.596
+        }
+    },
+    "10moon": {
+        "1060N": {
+            "width": 254,
+            "height": 152.4
+        }
+    },
+    "Turcom": {
+        "TS-6580": {
+            "width": 203.2,
+            "height": 127
+        }
+    },
+    "Uc-logic": {
+        "1060N": {
+            "width": 254,
+            "height": 152.4
+        },
+        "PF1209": {
+            "width": 305,
+            "height": 229
+        }
+    },
+    "Monoprice": {
+        "10594": {
+            "width": 254,
+            "height": 158.75
+        },
+        "MP1060-HA60": {
+            "width": 254,
+            "height": 158.75
+        }
+    },
+    "Waltop": {
+        "Slim Tablet": {
+            "width": 127,
+            "height": 76.2
+        }
+    },
+    "Xp-pen": {
+        "Artist 10S": {
+            "width": 216.96,
+            "height": 135.6
+        },
+        "Artist 13 (2nd Gen)": {
+            "width": 293.76,
+            "height": 165.24
+        },
+        "Deco L": {
+            "width": 254,
+            "height": 152.4
+        },
+        "Artist 16 Pro": {
+            "width": 341.07,
+            "height": 191.795
+        },
+        "Deco Pro LW Gen2": {
+            "width": 278.99,
+            "height": 173.99
+        },
+        "Artist 13.3": {
+            "width": 293.76,
+            "height": 165.24
+        },
+        "Artist 12": {
+            "width": 256.32,
+            "height": 144.18
+        },
+        "Innovator 16": {
+            "width": 343.915,
+            "height": 193.545
+        },
+        "Star G960S Plus": {
+            "width": 228.6,
+            "height": 152.4
+        },
+        "Deco Pro Medium": {
+            "width": 278.99,
+            "height": 156.995
+        },
+        "Star G640": {
+            "width": 160,
+            "height": 100
+        },
+        "Deco Pro SW": {
+            "width": 230.12,
+            "height": 129.54
+        },
+        "Deco mini7": {
+            "width": 177.8,
+            "height": 111.095
+        },
+        "Star G640S": {
+            "width": 165,
+            "height": 103
+        },
+        "Star 03 Pro": {
+            "width": 254,
+            "height": 152.4
+        },
+        "Artist 24 Pro": {
+            "width": 526.85,
+            "height": 296.35
+        },
+        "Star G430S": {
+            "width": 101.6,
+            "height": 76.2
+        },
+        "Deco 02": {
+            "width": 254,
+            "height": 142.875
+        },
+        "CT1060": {
+            "width": 254.505,
+            "height": 159.305
+        },
+        "Artist 15.6 Pro": {
+            "width": 344.16,
+            "height": 193.59
+        },
+        "Artist 16": {
+            "width": 344.16,
+            "height": 193.59
+        },
+        "Artist 22 (2nd Gen)": {
+            "width": 476.64,
+            "height": 267.78
+        },
+        "Deco 01 V2 (Variant 2)": {
+            "width": 254,
+            "height": 158.75
+        },
+        "Artist 10 (2nd Gen)": {
+            "width": 224.51,
+            "height": 126.695
+        },
+        "Star G640 (Variant 2)": {
+            "width": 160,
+            "height": 100
+        },
+        "Deco M": {
+            "width": 203.2,
+            "height": 127
+        },
+        "CT430": {
+            "width": 121.92,
+            "height": 76.2
+        },
+        "Star 06": {
+            "width": 254,
+            "height": 152.4
+        },
+        "Artist 12 Pro": {
+            "width": 256.34,
+            "height": 144.15
+        },
+        "Star G960": {
+            "width": 223.52,
+            "height": 139.7
+        },
+        "Star G430": {
+            "width": 101.6,
+            "height": 76.2
+        },
+        "Deco mini4": {
+            "width": 101.6,
+            "height": 76.2
+        },
+        "Star G430S V2": {
+            "width": 101.6,
+            "height": 76.2
+        },
+        "Artist 13.3 Pro": {
+            "width": 293.62,
+            "height": 165.1
+        },
+        "CT640": {
+            "width": 160,
+            "height": 101.6
+        },
+        "Artist Pro 16 (Gen2)": {
+            "width": 344.68,
+            "height": 215.42
+        },
+        "Artist 22HD": {
+            "width": 476.64,
+            "height": 268.11
+        },
+        "Artist 16 (2nd Gen)": {
+            "width": 340.99,
+            "height": 191.81
+        },
+        "Star G960S": {
+            "width": 228.8,
+            "height": 152.6
+        },
+        "Artist 12 (2nd Gen)": {
+            "width": 263.19,
+            "height": 148.08
+        },
+        "Star 05 V3": {
+            "width": 203.2,
+            "height": 127
+        },
+        "Star G540": {
+            "width": 228.6,
+            "height": 146.05
+        },
+        "Star 06C": {
+            "width": 254,
+            "height": 152.4
+        },
+        "Deco 03": {
+            "width": 254,
+            "height": 142.875
+        },
+        "Deco 01": {
+            "width": 254,
+            "height": 158.75
+        },
+        "Star 03": {
+            "width": 254,
+            "height": 152.4
+        },
+        "Deco Pro XLW Gen2": {
+            "width": 381,
+            "height": 229.005
+        },
+        "Deco Pro Small": {
+            "width": 230.12,
+            "height": 129.54
+        },
+        "Deco 01 V2": {
+            "width": 254,
+            "height": 158.75
+        },
+        "Artist 15.6": {
+            "width": 344.19,
+            "height": 194.61
+        },
+        "Star G540 Pro": {
+            "width": 136.8,
+            "height": 73.025
+        },
+        "Artist Pro 16TP": {
+            "width": 345.615,
+            "height": 194.385
+        }
+    },
+    "Ugee": {
+        "S640": {
+            "width": 159.99,
+            "height": 99.97
+        },
+        "U1600": {
+            "width": 344.14,
+            "height": 193.57
+        },
+        "U1200": {
+            "width": 263.22,
+            "height": 148.055
+        },
+        "M908": {
+            "width": 254,
+            "height": 158.75
+        },
+        "M708": {
+            "width": 200,
+            "height": 120
+        },
+        "M808": {
+            "width": 254,
+            "height": 158.75
+        },
+        "S1060": {
+            "width": 254,
+            "height": 160
+        },
+        "M708 V2": {
+            "width": 253.96,
+            "height": 152.305
+        }
+    },
+    "Robotpen": {
+        "T9A": {
+            "width": 295.11,
+            "height": 216.69
+        }
+    },
+    "Gaomon": {
+        "M10K Pro": {
+            "width": 254.1,
+            "height": 158.75
+        },
+        "GM156HD": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "M1220": {
+            "width": 258.5,
+            "height": 161.55
+        },
+        "M8 (Variant 2)": {
+            "width": 258.465,
+            "height": 161.535
+        },
+        "S830": {
+            "width": 182.3,
+            "height": 107.7
+        },
+        "S630": {
+            "width": 129.3,
+            "height": 80.8
+        },
+        "M1230": {
+            "width": 258.5,
+            "height": 171.525
+        },
+        "S620": {
+            "width": 165.1,
+            "height": 101.6
+        },
+        "M8": {
+            "width": 258.465,
+            "height": 161.535
+        },
+        "M106K": {
+            "width": 200,
+            "height": 125
+        },
+        "M6": {
+            "width": 254,
+            "height": 158.75
+        },
+        "PD2200": {
+            "width": 476.765,
+            "height": 268.225
+        },
+        "M106K Pro": {
+            "width": 254,
+            "height": 158.75
+        },
+        "PD1561": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "S56K": {
+            "width": 160,
+            "height": 120
+        },
+        "GM116HD": {
+            "width": 256.3,
+            "height": 144.2
+        },
+        "PD156 Pro": {
+            "width": 344.4,
+            "height": 193.6
+        },
+        "PD1161": {
+            "width": 256.32,
+            "height": 144.18
+        },
+        "PD1560": {
+            "width": 344.16,
+            "height": 193.59
+        },
+        "M10K": {
+            "width": 254,
+            "height": 158.75
+        },
+        "1060 Pro": {
+            "width": 254,
+            "height": 158.75
+        }
+    },
+    "Acepen": {
+        "AP906": {
+            "width": 229.87,
+            "height": 142.24
+        },
+        "AP1060": {
+            "width": 254,
+            "height": 152.4
+        }
+    },
+    "Huion": {
+        "Q630M": {
+            "width": 266.7,
+            "height": 166.7
+        },
+        "H950P": {
+            "width": 221,
+            "height": 138
+        },
+        "Kamvas Pro 22 (2019)": {
+            "width": 476.75,
+            "height": 268.22
+        },
+        "Kamvas Pro 12": {
+            "width": 267.9,
+            "height": 168.2
+        },
+        "HS95": {
+            "width": 203.19,
+            "height": 126.99
+        },
+        "Kamvas 13": {
+            "width": 293.76,
+            "height": 165.24
+        },
+        "WH1409 V2 (Variant 2)": {
+            "width": 350.52,
+            "height": 219.0623
+        },
+        "Kamvas 13 (Gen 3)": {
+            "width": 293.8,
+            "height": 165.2
+        },
+        "Kamvas 22 Plus": {
+            "width": 476.64,
+            "height": 268.11
+        },
+        "H420": {
+            "width": 101.6,
+            "height": 57.01295
+        },
+        "GT-221": {
+            "width": 476.73,
+            "height": 268.205
+        },
+        "H690": {
+            "width": 228.6,
+            "height": 142.875
+        },
+        "HS611": {
+            "width": 258.4,
+            "height": 161.5
+        },
+        "H951P": {
+            "width": 221,
+            "height": 138
+        },
+        "H1061P": {
+            "width": 266.7,
+            "height": 166.7
+        },
+        "Kamvas Pro 24 (4K)": {
+            "width": 527.04,
+            "height": 296.46
+        },
+        "Kamvas 16 (2021)": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "H640P": {
+            "width": 160,
+            "height": 100
+        },
+        "Kamvas 24 Plus": {
+            "width": 526.85,
+            "height": 296.35
+        },
+        "H420X": {
+            "width": 106,
+            "height": 66
+        },
+        "G10T": {
+            "width": 254,
+            "height": 158.75
+        },
+        "Kamvas Pro 24": {
+            "width": 526.895,
+            "height": 296.18
+        },
+        "New 1060 Plus": {
+            "width": 254,
+            "height": 158.75
+        },
+        "RTM 500": {
+            "width": 220.995,
+            "height": 137.995
+        },
+        "Kamvas Pro 16 Plus (4k)": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "WH1409": {
+            "width": 350,
+            "height": 218
+        },
+        "H610 Pro V2": {
+            "width": 254,
+            "height": 158.75
+        },
+        "H610 Pro V3": {
+            "width": 254,
+            "height": 158.75
+        },
+        "Kamvas Pro 16 (4k)": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "1060 Plus": {
+            "width": 254,
+            "height": 158.75
+        },
+        "HS64": {
+            "width": 160,
+            "height": 102
+        },
+        "Kamvas Pro 16": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "H1161": {
+            "width": 279.4,
+            "height": 174.625
+        },
+        "420": {
+            "width": 101.6,
+            "height": 57.01295
+        },
+        "Kamvas Pro 13": {
+            "width": 293.76,
+            "height": 165.24
+        },
+        "H430P": {
+            "width": 121.92,
+            "height": 76.2
+        },
+        "Kamvas 12": {
+            "width": 267.9,
+            "height": 168.2
+        },
+        "Kamvas 22": {
+            "width": 476.76,
+            "height": 268.225
+        },
+        "WH1409 V2": {
+            "width": 350,
+            "height": 218
+        },
+        "GT-156HD V2": {
+            "width": 343.9,
+            "height": 193.55
+        },
+        "Q620M": {
+            "width": 266.7,
+            "height": 165.1
+        },
+        "Kamvas 20": {
+            "width": 434.75,
+            "height": 238.75
+        },
+        "H642": {
+            "width": 160.02,
+            "height": 99.06
+        },
+        "HS610": {
+            "width": 254,
+            "height": 158.75
+        },
+        "Kamvas Pro 16 (2.5k)": {
+            "width": 349.63,
+            "height": 196.665
+        },
+        "Q11K": {
+            "width": 279.4,
+            "height": 174.625
+        },
+        "GC610": {
+            "width": 254,
+            "height": 158.75
+        },
+        "H1060P": {
+            "width": 254,
+            "height": 158.75
+        },
+        "H641P": {
+            "width": 160,
+            "height": 100
+        },
+        "Kamvas 16": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "Kamvas Pro 19 (4K)": {
+            "width": 408.96,
+            "height": 230.03
+        },
+        "Q11K V2": {
+            "width": 279.4,
+            "height": 174.625
+        },
+        "RDS-160": {
+            "width": 344.2,
+            "height": 193.6
+        },
+        "New 1060 Plus (2048)": {
+            "width": 254,
+            "height": 158.75
+        },
+        "H580X": {
+            "width": 203.2,
+            "height": 127
+        },
+        "H610 Pro": {
+            "width": 254,
+            "height": 158.75
+        },
+        "H320M": {
+            "width": 228.5,
+            "height": 142.9
+        },
+        "H610X": {
+            "width": 254,
+            "height": 158.8
+        },
+        "Kamvas Pro 20": {
+            "width": 435.375,
+            "height": 238.75
+        },
+        "GT-220 V2": {
+            "width": 476.68,
+            "height": 268.145
+        },
+        "GT-221 Pro": {
+            "width": 476.73,
+            "height": 268.205
+        },
+        "HC16": {
+            "width": 254,
+            "height": 158.75
+        },
+        "RTP-700": {
+            "width": 279.4,
+            "height": 174.6
+        },
+        "Kamvas Pro 13 (2.5k)": {
+            "width": 286.465,
+            "height": 179.04
+        },
+        "RTE-100": {
+            "width": 121.92,
+            "height": 76.19
+        },
+        "G930L": {
+            "width": 345.44,
+            "height": 215.9
+        }
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pick"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "windows-curses", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/f5/980b90af3fd82d18adaa3a1249037d3b1f95e201d640e17a7c5ce6188f45/pick-2.4.0.tar.gz", hash = "sha256:71f1b1b5d83652f87652fea5f51a3ba0b3388a71718cdcf8c6bc1326f85ae0b9", size = 5085 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/95/c1ed539b784246182fd04a3fdee6ba473518e658c84d776caa714904d0f9/pick-2.4.0-py3-none-any.whl", hash = "sha256:2b07be18d16d655c7f491e1ecca7a29de3be85e1e000c8d46193672f14faa203", size = 5515 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -193,15 +205,15 @@ wheels = [
 
 [[package]]
 name = "pyinstaller-hooks-contrib"
-version = "2025.1"
+version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/1b/dc256d42f4217db99b50d6d32dbbf841a41b9615506cde77d2345d94f4a5/pyinstaller_hooks_contrib-2025.1.tar.gz", hash = "sha256:130818f9e9a0a7f2261f1fd66054966a3a50c99d000981c5d1db11d3ad0c6ab2", size = 147043 }
+sdist = { url = "https://files.pythonhosted.org/packages/99/14/6725808804b52cc2420a659c8935e511221837ad863e3bbc4269897d5b4d/pyinstaller_hooks_contrib-2025.2.tar.gz", hash = "sha256:ccdd41bc30290f725f3e48f4a39985d11855af81d614d167e3021e303acb9102", size = 150122 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/48/833d67a585275e395f351e5787b4b7a8d462d87bca22a8c038f6ffdc2b3c/pyinstaller_hooks_contrib-2025.1-py3-none-any.whl", hash = "sha256:d3c799470cbc0bda60dcc8e6b4ab976777532b77621337f2037f558905e3a8e9", size = 346409 },
+    { url = "https://files.pythonhosted.org/packages/5e/14/aaadab954b4d78b2de9368eabda3327f8cdd05bce12712263e1100266bca/pyinstaller_hooks_contrib-2025.2-py3-none-any.whl", hash = "sha256:0b2bc7697075de5eb071ff13ef4a156d3beae6c19c7cbdcd70f37978d2013e30", size = 351020 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3,21 +3,40 @@ revision = 1
 requires-python = ">=3.12"
 
 [[package]]
+name = "altgraph"
+version = "0.17.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/a8/7145824cf0b9e3c28046520480f207df47e927df83aa9555fb47f8505922/altgraph-0.17.4.tar.gz", hash = "sha256:1b5afbb98f6c4dcadb2e2ae6ab9fa994bbb8c1d75f4fa96d340f9437ae454406", size = 48418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/3f/3bc3f1d83f6e4a7fcb834d3720544ca597590425be5ba9db032b2bf322a2/altgraph-0.17.4-py2.py3-none-any.whl", hash = "sha256:642743b4750de17e655e6711601b077bc6598dbfa3ba5fa2b2a35ce12b508dff", size = 21212 },
+]
+
+[[package]]
 name = "area-calculator-osu"
-version = "0.2.1"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "numpy" },
+    { name = "pick" },
     { name = "pynput" },
     { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyinstaller" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=2.2.4" },
+    { name = "pick", specifier = ">=2.4.0" },
     { name = "pynput", specifier = ">=1.8.1" },
     { name = "typer", specifier = ">=0.15.2" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyinstaller", specifier = ">=6.12.0" }]
 
 [[package]]
 name = "click"
@@ -45,6 +64,18 @@ name = "evdev"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d1/99/4d24bb6db12fc170a5f209f4c9108054a2c84d289d1e7f743e979b202023/evdev-1.9.1.tar.gz", hash = "sha256:dc640a064cb1c9fe1f8b970dc2039945a2a275d7b7ee62284bf427238abe45ee", size = 33349 }
+
+[[package]]
+name = "macholib"
+version = "1.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/ee/af1a3842bdd5902ce133bd246eb7ffd4375c38642aeb5dc0ae3a0329dfa2/macholib-1.16.3.tar.gz", hash = "sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30", size = 59309 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/5d/c059c180c84f7962db0aeae7c3b9303ed1d73d76f2bfbc32bc231c8be314/macholib-1.16.3-py2.py3-none-any.whl", hash = "sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c", size = 38094 },
+]
 
 [[package]]
 name = "markdown-it-py"
@@ -106,12 +137,83 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pefile"
+version = "2023.2.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791 },
+]
+
+[[package]]
+name = "pick"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "windows-curses", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/f5/980b90af3fd82d18adaa3a1249037d3b1f95e201d640e17a7c5ce6188f45/pick-2.4.0.tar.gz", hash = "sha256:71f1b1b5d83652f87652fea5f51a3ba0b3388a71718cdcf8c6bc1326f85ae0b9", size = 5085 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/95/c1ed539b784246182fd04a3fdee6ba473518e658c84d776caa714904d0f9/pick-2.4.0-py3-none-any.whl", hash = "sha256:2b07be18d16d655c7f491e1ecca7a29de3be85e1e000c8d46193672f14faa203", size = 5515 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/c0/001e86a13f9f6104613f198721c72d377fa1fc2a09550cfe1ac9a1d12406/pyinstaller-6.12.0.tar.gz", hash = "sha256:1834797be48ce1b26015af68bdeb3c61a6c7500136f04e0fc65e468115dec777", size = 4267132 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/73/b897a3fda99a14130111abdb978d63da14cbc9932497b5e5064c5fe28187/pyinstaller-6.12.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:68f1e4cecf88a6272063977fa2a2c69ad37cf568e5901769d7206d0314c74f47", size = 997954 },
+    { url = "https://files.pythonhosted.org/packages/4a/bc/0929ed6aca3c5ff3f20f8cfd4f2f7e90f18c9465440e0d151d56d8170851/pyinstaller-6.12.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:fea76fc9b55ffa730fcf90beb897cce4399938460b0b6f40507fbebfc752c753", size = 714097 },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/422d5eb04132e4a4735ca9099a53511324ff7d387b80231fe8dbd67bf322/pyinstaller-6.12.0-py3-none-manylinux2014_i686.whl", hash = "sha256:dac8a27988dbc33cdc34f2046803258bc3f6829de24de52745a5daa22bdba0f1", size = 724471 },
+    { url = "https://files.pythonhosted.org/packages/64/1c/5028ba2e09f5b57f6792e9d88e888725224f8f016a07666e48664f6a9fcf/pyinstaller-6.12.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:83c7f3bde9871b4a6aa71c66a96e8ba5c21668ce711ed97f510b9382d10aac6c", size = 722753 },
+    { url = "https://files.pythonhosted.org/packages/6f/d9/e7742caf4c4dc07d13e355ad2c14c7844c9bb2e66dea4f3386b4644bd106/pyinstaller-6.12.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:a69818815c6e0711c727edc30680cb1f81c691b59de35db81a2d9e0ae26a9ef1", size = 720906 },
+    { url = "https://files.pythonhosted.org/packages/80/2b/14404f2dc95d1ec94d08879c62a76d5f26a176fab99fb023c2c70d2ff500/pyinstaller-6.12.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a2abf5fde31a8b38b6df7939bcef8ac1d0c51e97e25317ce3555cd675259750f", size = 716959 },
+    { url = "https://files.pythonhosted.org/packages/11/a6/5c3a233cf19aa6d4caacf62f7ee1c728486cc20b73f5817be17485d7b7ff/pyinstaller-6.12.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:8e92e9873a616547bbabbb5a3a9843d5f2ab40c3d8b26810acdf0fe257bee4cf", size = 719414 },
+    { url = "https://files.pythonhosted.org/packages/24/57/069d35236806b281a3331ef00ff94e43f3b91e4b36350de8b40b4baf9fd3/pyinstaller-6.12.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:aefe502d55c9cf6aeaed7feba80b5f8491ce43f8f2b5fe2d9aadca3ee5a05bc4", size = 715903 },
+    { url = "https://files.pythonhosted.org/packages/4d/5f/857de8798836f9d16a620bd0a7c8899bba05b5fda7b3b4432762f148a86d/pyinstaller-6.12.0-py3-none-win32.whl", hash = "sha256:138856a5a503bb69c066377e0a22671b0db063e9cc14d5cf5c798a53561200d3", size = 1290980 },
+    { url = "https://files.pythonhosted.org/packages/99/6e/d7d76d4d15f6351f1f942256633b795eec3d6c691d985869df1bf319cd9d/pyinstaller-6.12.0-py3-none-win_amd64.whl", hash = "sha256:0e62d3906309248409f215b386f33afec845214e69cc0f296b93222b26a88f43", size = 1348786 },
+    { url = "https://files.pythonhosted.org/packages/47/c2/298ad6a3aa2cacb55cbc1f845068dc1e4a6c966082ffa0e19c69084cbc42/pyinstaller-6.12.0-py3-none-win_arm64.whl", hash = "sha256:0c271896a3a168f4f91827145702543db9c5427f4c7372a6df8c75925a3ac18a", size = 1289617 },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2025.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/1b/dc256d42f4217db99b50d6d32dbbf841a41b9615506cde77d2345d94f4a5/pyinstaller_hooks_contrib-2025.1.tar.gz", hash = "sha256:130818f9e9a0a7f2261f1fd66054966a3a50c99d000981c5d1db11d3ad0c6ab2", size = 147043 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/48/833d67a585275e395f351e5787b4b7a8d462d87bca22a8c038f6ffdc2b3c/pyinstaller_hooks_contrib-2025.1-py3-none-any.whl", hash = "sha256:d3c799470cbc0bda60dcc8e6b4ab976777532b77621337f2037f558905e3a8e9", size = 346409 },
 ]
 
 [[package]]
@@ -216,6 +318,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756 },
+]
+
+[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -226,6 +337,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "setuptools"
+version = "77.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/ed/7101d53811fd359333583330ff976e5177c5e871ca8b909d1d6c30553aa3/setuptools-77.0.3.tar.gz", hash = "sha256:583b361c8da8de57403743e756609670de6fb2345920e36dc5c2d914c319c945", size = 1367236 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/07/99f2cefae815c66eb23148f15d79ec055429c38fa8986edcc712ab5f3223/setuptools-77.0.3-py3-none-any.whl", hash = "sha256:67122e78221da5cf550ddd04cf8742c8fe12094483749a792d56cd669d6cf58c", size = 1255678 },
 ]
 
 [[package]]
@@ -268,4 +388,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "windows-curses"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/99/60f34e51514c82631aa5c6d21eab88ce1701562de9844608411e39462a46/windows_curses-2.4.1-cp312-cp312-win32.whl", hash = "sha256:bdbe7d58747408aef8a9128b2654acf6fbd11c821b91224b9a046faba8c6b6ca", size = 71489 },
+    { url = "https://files.pythonhosted.org/packages/62/8f/d908bcab1954375b156a9300fa86ceccb110f39457cd6fd59c72777626ab/windows_curses-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c9c2635faf171a229caca80e1dd760ab00db078e2a285ba2f667bbfcc31777c", size = 81777 },
+    { url = "https://files.pythonhosted.org/packages/25/a0/e8d074f013117633f6b502ca123ecfc377fe0bd36818fe65e8935c91ca9c/windows_curses-2.4.1-cp313-cp313-win32.whl", hash = "sha256:05d1ca01e5199a435ccb6c8c2978df4a169cdff1ec99ab15f11ded9de8e5be26", size = 71390 },
+    { url = "https://files.pythonhosted.org/packages/2b/4b/2838a829b074a68c570d54ae0ae8539979657d3e619a4dc5a4b03eb69745/windows_curses-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8cf653f8928af19c103ae11cfed38124f418dcdd92643c4cd17239c0cec2f9da", size = 81636 },
 ]


### PR DESCRIPTION
It is easier for users to just select their tablet instead of looking up their full active area online
Manual tablet input is still available by exiting this menu (pressing Q)
![image](https://github.com/user-attachments/assets/9d304615-2bc8-4192-b2fc-4ce77da178f4)
![image](https://github.com/user-attachments/assets/262b04aa-28b2-41a2-a7c4-f98b17cd4eff)
